### PR TITLE
Fix get a value from opts when less than Ruby 2.0.0

### DIFF
--- a/lib/agig/session.rb
+++ b/lib/agig/session.rb
@@ -22,7 +22,7 @@ class Agig::Session < Net::IRC::Server::Session
   end
 
   def client
-    @client ||= if @opts["oauth_token"]
+    @client ||= if @opts.oauth_token
                   Octokit::Client.new(oauth_token: @pass)
                 else
                   Octokit::Client.new(login: @nick, password: @pass)


### PR DESCRIPTION
[OpenStruct support to the `[]` is Ruby 2.0.0 or later](https://github.com/ruby/ruby/blob/e44e356b53828d6468114b30e5c169296896f9b1/lib/ostruct.rb).

```
E, [2013-07-04T22:45:17.377081 #42693] ERROR -- : #<NoMethodError: undefined method `[]' for #<OpenStruct oauth_token=true>>
E, [2013-07-04T22:45:17.377163 #42693] ERROR -- :       /Users/ykzts/work/agig/lib/agig/session.rb:25:in `client'
E, [2013-07-04T22:45:17.377208 #42693] ERROR -- :       /Users/ykzts/work/agig/lib/agig/session.rb:56:in `block (2 levels) in on_user'
E, [2013-07-04T22:45:17.377253 #42693] ERROR -- :       /Users/ykzts/work/agig/lib/agig/session.rb:52:in `loop'
E, [2013-07-04T22:45:17.377297 #42693] ERROR -- :       /Users/ykzts/work/agig/lib/agig/session.rb:52:in `block in on_user'
```
