### PR TITLE
Use notifications API options (:all and :since)

### DIFF
--- a/lib/agig/session.rb
+++ b/lib/agig/session.rb
@@ -53,10 +53,9 @@ class Agig::Session < Net::IRC::Server::Session
         begin
           @log.info 'retrieveing feed...'
 
-          entries = client.notifications
+          entries = client.notifications(all: true, since: @notification_last_retrieved.iso8601)
           entries.sort_by(&:updated_at).reverse_each do |entry|
             updated_at = Time.parse(entry.updated_at).utc
-            next if updated_at <= @notification_last_retrieved
 
             reachable_url = reachable_url_for(entry.subject.latest_comment_url)
 


### PR DESCRIPTION
> **all**
> _Optional_ **boolean** `true` to show notifications marked as read.
> 
> **participating**
> _Optional_ **boolean** `true` to show only notifications in which the user is directly participating or mentioned.
> 
> **since**
> _Optional_ **time** filters out any notifications updated before the given time. The time should be passed in as UTC in the ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Example: “2012-10-09T23:39:01Z”.

cite: http://developer.github.com/v3/activity/notifications/#list-your-notifications
