### PR TITLE
Freezed version of octokit

### DIFF
--- a/agig.gemspec
+++ b/agig.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'net-irc'
   gem.add_dependency 'json'
   gem.add_dependency 'faraday', '~> 0.8.7'
-  gem.add_dependency 'octokit'
+  gem.add_dependency 'octokit', '~> 1.25'
 
   gem.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Parse error has occured when using octokit version 2.0 or higher. This PR freezes octokit version.

```
I, [2013-09-26T08:53:01.936533 #887]  INFO -- : retrieveing feed...
E, [2013-09-26T08:53:03.212837 #887] ERROR -- : #<TypeError: no implicit conversion of Time into String>
E, [2013-09-26T08:53:03.212920 #887] ERROR -- :         /Users/ryutaro/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/time.rb:325:in `_parse'
E, [2013-09-26T08:53:03.212943 #887] ERROR -- :         /Users/ryutaro/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/time.rb:325:in `parse'
E, [2013-09-26T08:53:03.212963 #887] ERROR -- :         /Users/ryutaro/Developments/Ruby/agig/lib/agig/session.rb:58:in `block (3 levels) in on_user'
E, [2013-09-26T08:53:03.212981 #887] ERROR -- :         /Users/ryutaro/Developments/Ruby/agig/lib/agig/session.rb:57:in `reverse_each'
E, [2013-09-26T08:53:03.212999 #887] ERROR -- :         /Users/ryutaro/Developments/Ruby/agig/lib/agig/session.rb:57:in `block (2 levels) in on_user'
E, [2013-09-26T08:53:03.213026 #887] ERROR -- :         /Users/ryutaro/Developments/Ruby/agig/lib/agig/session.rb:52:in `loop'
E, [2013-09-26T08:53:03.213050 #887] ERROR -- :         /Users/ryutaro/Developments/Ruby/agig/lib/agig/session.rb:52:in `block in on_user'
```

このエラーは下記の変更による影響のようです。
https://github.com/octokit/octokit.rb#upgrading-guide

> Hashie::Mash has been removed. Responses now return a Sawyer::Resource object. This new type behaves mostly like a Ruby Hash, but does not fully support the Hashie::Mash API.
